### PR TITLE
Bypass hooks for Forgejo mirror push

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -32,7 +32,7 @@ jobs:
           set -eu
           test -n "$FORGEJO_MIRROR_TOKEN"
           git remote add forgejo "https://richardtmiles:${FORGEJO_MIRROR_TOKEN}@git.miles.systems/CarbonORM/CarbonORM.dev.git"
-          git push forgejo "${GITHUB_SHA}:refs/heads/www"
+          git push --no-verify forgejo "${GITHUB_SHA}:refs/heads/www"
 
       - name: Publish Harvester artifact branch
         env:


### PR DESCRIPTION
## Summary
- bypass the repo pre-push hook during the GitHub Actions Forgejo source mirror push

## Validation
- ruby YAML parse for .github/workflows/npm.yml

This follows up on the post-merge failure from PR #2, where the Actions checkout installed the repo pre-push hook and tried to run the legacy full build during git push.