### PR TITLE
Fetch full history for Forgejo mirror

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps


### PR DESCRIPTION
## Summary
- check out full history before the Forgejo mirror push so Git can verify the update against Forgejo

## Validation
- ruby YAML parse for .github/workflows/npm.yml

This follows the same full-history pattern used by the CarbonC Forgejo mirror workflow.